### PR TITLE
Minor refactor for CodMwStats.ApiWrapper

### DIFF
--- a/CodMwStats.ApiWrapper/ApiHelper.cs
+++ b/CodMwStats.ApiWrapper/ApiHelper.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
-using CodMwStats.ApiWrapper.Models;
 
 namespace CodMwStats.ApiWrapper
 {

--- a/CodMwStats.ApiWrapper/ApiProcessor.cs
+++ b/CodMwStats.ApiWrapper/ApiProcessor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
-using CodMwStats.ApiWrapper.Models;
+﻿using System.Threading.Tasks;
 
 namespace CodMwStats.ApiWrapper
 {

--- a/CodMwStats.ApiWrapper/Models/Accolades.cs
+++ b/CodMwStats.ApiWrapper/Models/Accolades.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace CodMwStats.ApiWrapper.Models
+﻿namespace CodMwStats.ApiWrapper.Models
 {
     public class Accolades
     {

--- a/CodMwStats.ApiWrapper/Models/Information.cs
+++ b/CodMwStats.ApiWrapper/Models/Information.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models
 {

--- a/CodMwStats.ApiWrapper/Models/Metadata.cs
+++ b/CodMwStats.ApiWrapper/Models/Metadata.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models

--- a/CodMwStats.ApiWrapper/Models/ModerWarfareApiOutput.cs
+++ b/CodMwStats.ApiWrapper/Models/ModerWarfareApiOutput.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models
 {

--- a/CodMwStats.ApiWrapper/Models/ModerWarfarePlayer.cs
+++ b/CodMwStats.ApiWrapper/Models/ModerWarfarePlayer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace CodMwStats.ApiWrapper.Models
+{
+    public class ModerWarfarePlayer
+    {
+        public string Name { get; }
+        public Uri ProfilePicURl { get; }
+        public double? Playtime { get; }
+        public double? Matches { get; }
+        public Uri LevelImageUrl { get;  }
+        public double? Level { get; }
+        public double? LevelProgression { get; }
+        public double? KillDeathRatio { get; }
+        public double? Kills { get; }
+        public double? WinLossRation { get; }
+        public double? Wins { get; }
+        public double? Losses { get; }
+        public double? BestKillStreak { get; }
+        public double? Deaths { get; }
+        public double? AverageLife { get; }
+        public double? Assists { get; }
+        public double? Score { get; }
+
+        public ModerWarfarePlayer(ModerWarfareApiOutput apiOutput)
+        {
+            Name = apiOutput.Data.PlatformInfo.PlatformUserHandle;
+            ProfilePicURl = new Uri(apiOutput.Data.PlatformInfo.AvatarUrl);
+            Playtime = apiOutput.Data.Segment[0].Stats.TotalGamesPlayed.Value;
+            LevelImageUrl = apiOutput.Data.Segment[0].Stats.Level.Metadata.IconUrl;
+            Level = apiOutput.Data.Segment[0].Stats.Level.Value;
+            LevelProgression = apiOutput.Data.Segment[0].Stats.LevelProgression.Value;
+            KillDeathRatio = apiOutput.Data.Segment[0].Stats.KdRatio.Value;
+            Kills = apiOutput.Data.Segment[0].Stats.Kills.Value;
+            WinLossRation = apiOutput.Data.Segment[0].Stats.WlRatio.Value;
+            Wins = apiOutput.Data.Segment[0].Stats.Wins.Value;
+            BestKillStreak = apiOutput.Data.Segment[0].Stats.LongestKillstreak.Value;
+            Losses = apiOutput.Data.Segment[0].Stats.Losses.Value;
+            Deaths = apiOutput.Data.Segment[0].Stats.Deaths.Value;
+            AverageLife = apiOutput.Data.Segment[0].Stats.AverageLife.Value;
+            Assists = apiOutput.Data.Segment[0].Stats.Assists.Value;
+            Score = apiOutput.Data.Segment[0].Stats.CareerScore.Value;
+        }
+    }
+}

--- a/CodMwStats.ApiWrapper/Models/ModernWarfareUser.cs
+++ b/CodMwStats.ApiWrapper/Models/ModernWarfareUser.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models
 {

--- a/CodMwStats.ApiWrapper/Models/Overview.cs
+++ b/CodMwStats.ApiWrapper/Models/Overview.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models
 {

--- a/CodMwStats.ApiWrapper/Models/PlatformInfo.cs
+++ b/CodMwStats.ApiWrapper/Models/PlatformInfo.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models
 {

--- a/CodMwStats.ApiWrapper/Models/Stats.cs
+++ b/CodMwStats.ApiWrapper/Models/Stats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace CodMwStats.ApiWrapper.Models
 {

--- a/CodMwStats.Commands/MainStatsCommands/BattleNetStats.cs
+++ b/CodMwStats.Commands/MainStatsCommands/BattleNetStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using CodMwStats.ApiWrapper;
 using CodMwStats.ApiWrapper.Models;
 using Discord;
@@ -33,48 +30,29 @@ namespace CodMwStats.Commands.MainStatsCommands
             var jsonAsString = await ApiProcessor.GetUser($"https://api.tracker.gg/api/v2/modern-warfare/standard/profile/battlenet/{userName}");
             var apiData = JsonConvert.DeserializeObject<ModerWarfareApiOutput>(jsonAsString);
 
-            var name = apiData.Data.PlatformInfo.PlatformUserHandle;
-            var pfp = apiData.Data.PlatformInfo.AvatarUrl;
-            var playTime = apiData.Data.Segment[0].Stats.TimePlayedTotal.Value;
-            var matches = apiData.Data.Segment[0].Stats.TotalGamesPlayed.Value;
-            var levelImg = apiData.Data.Segment[0].Stats.Level.Metadata.IconUrl;
-            var level = apiData.Data.Segment[0].Stats.Level.Value;
-            var levelper = apiData.Data.Segment[0].Stats.LevelProgression.Value;
-            var kd = apiData.Data.Segment[0].Stats.KdRatio.Value;
-            var kills = apiData.Data.Segment[0].Stats.Kills.Value;
-            var WinPer = apiData.Data.Segment[0].Stats.WlRatio.Value;
-            var wins = apiData.Data.Segment[0].Stats.Wins.Value;
-            var bestKillsreak = apiData.Data.Segment[0].Stats.LongestKillstreak.Value;
-            var losses = apiData.Data.Segment[0].Stats.Losses.Value;
-            var deaths = apiData.Data.Segment[0].Stats.Deaths.Value;
-            var avgLife = apiData.Data.Segment[0].Stats.AverageLife.Value;
-            var assists = apiData.Data.Segment[0].Stats.Assists.Value;
-            var Score = apiData.Data.Segment[0].Stats.CareerScore.Value;
+            var player = new ModerWarfarePlayer(apiData);
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle($"Stats of {name}");
-            embed.WithThumbnailUrl(pfp);
-            embed.AddField("Play Time:", playTime);
-            embed.AddField("Matches:", matches);
-            embed.AddField("Level:", level);
-            embed.AddField("Level Progression:", levelper);
-            embed.WithImageUrl(levelImg.ToString());
-            embed.AddField("K/D Ratio:", kd);
-            embed.AddField("Kills:", kills);
-            embed.AddField("Win %:", WinPer);
-            embed.AddField("Wins:", wins);
+            var embed = new EmbedBuilder()
+                .WithTitle($"Stats of {player.Name}")
+                .WithThumbnailUrl(player.ProfilePicURl.AbsoluteUri)
+                .AddField("Play Time:", player.Playtime)
+                .AddField("Matches:", player.Matches)
+                .AddField("Level:", player.Level)
+                .AddField("Level Progression:", player.LevelProgression)
+                .WithImageUrl(player.LevelImageUrl.AbsoluteUri)
+                .AddField("K/D Ratio:", player.KillDeathRatio)
+                .AddField("Kills:", player.Kills)
+                .AddField("Win %:", player.WinLossRation)
+                .AddField("Wins:", player.Wins)
+                .AddField("Best Killstreak:", player.BestKillStreak)
+                .AddField("Losses:", player.Losses)
+                .AddField("Deaths:", player.Deaths)
+                .AddField("Avg. Life:", player.AverageLife)
+                .AddField("Assists:", player.Assists)
+                .AddField("Score:", player.Score)
+                .WithColor(new Color(239, 133, 141));
 
-            embed.AddField("Best Killstreak:", bestKillsreak);
-            embed.AddField("Losses:", losses);
-            embed.AddField("Deaths:", deaths);
-            embed.AddField("Avg. Life:", avgLife);
-            embed.AddField("Assists:", assists);
-            embed.AddField("Score:", Score);
-
-
-            embed.WithColor(new Color(239, 133, 141));
-
-            var msg = await Context.Channel.SendMessageAsync("", false, embed.Build());
+            await Context.Channel.SendMessageAsync(embed: embed.Build());
         }
     }
 }

--- a/CodMwStats.Commands/MainStatsCommands/PS4Stats.cs
+++ b/CodMwStats.Commands/MainStatsCommands/PS4Stats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using CodMwStats.ApiWrapper;
 using CodMwStats.ApiWrapper.Models;
 using Discord;
@@ -19,48 +16,29 @@ namespace CodMwStats.Commands.MainStatsCommands
             var jsonAsString = await ApiProcessor.GetUser($"https://api.tracker.gg/api/v2/modern-warfare/standard/profile/psn/{userName}");
             var apiData = JsonConvert.DeserializeObject<ModerWarfareApiOutput>(jsonAsString);
 
-            var name = apiData.Data.PlatformInfo.PlatformUserHandle;
-            var pfp = apiData.Data.PlatformInfo.AvatarUrl;
-            var playTime = apiData.Data.Segment[0].Stats.TimePlayedTotal.Value;
-            var matches = apiData.Data.Segment[0].Stats.TotalGamesPlayed.Value;
-            var levelImg = apiData.Data.Segment[0].Stats.Level.Metadata.IconUrl;
-            var level = apiData.Data.Segment[0].Stats.Level.Value;
-            var levelper = apiData.Data.Segment[0].Stats.LevelProgression.Value;
-            var kd = apiData.Data.Segment[0].Stats.KdRatio.Value;
-            var kills = apiData.Data.Segment[0].Stats.Kills.Value;
-            var WinPer = apiData.Data.Segment[0].Stats.WlRatio.Value;
-            var wins = apiData.Data.Segment[0].Stats.Wins.Value;
-            var bestKillsreak = apiData.Data.Segment[0].Stats.LongestKillstreak.Value;
-            var losses = apiData.Data.Segment[0].Stats.Losses.Value;
-            var deaths = apiData.Data.Segment[0].Stats.Deaths.Value;
-            var avgLife = apiData.Data.Segment[0].Stats.AverageLife.Value;
-            var assists = apiData.Data.Segment[0].Stats.Assists.Value;
-            var Score = apiData.Data.Segment[0].Stats.CareerScore.Value;
+            var player = new ModerWarfarePlayer(apiData);
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle($"Stats of {name}");
-            embed.WithThumbnailUrl(pfp);
-            embed.AddField("Play Time:", playTime);
-            embed.AddField("Matches:", matches);
-            embed.AddField("Level:", level);
-            embed.AddField("Level Progression:", levelper);
-            embed.WithImageUrl(levelImg.ToString());
-            embed.AddField("K/D Ratio:", kd);
-            embed.AddField("Kills:", kills);
-            embed.AddField("Win %:", WinPer);
-            embed.AddField("Wins:", wins);
+            var embed = new EmbedBuilder()
+                .WithTitle($"Stats of {player.Name}")
+                .WithThumbnailUrl(player.ProfilePicURl.AbsoluteUri)
+                .AddField("Play Time:", player.Playtime)
+                .AddField("Matches:", player.Matches)
+                .AddField("Level:", player.Level)
+                .AddField("Level Progression:", player.LevelProgression)
+                .WithImageUrl(player.LevelImageUrl.AbsoluteUri)
+                .AddField("K/D Ratio:", player.KillDeathRatio)
+                .AddField("Kills:", player.Kills)
+                .AddField("Win %:", player.WinLossRation)
+                .AddField("Wins:", player.Wins)
+                .AddField("Best Killstreak:", player.BestKillStreak)
+                .AddField("Losses:", player.Losses)
+                .AddField("Deaths:", player.Deaths)
+                .AddField("Avg. Life:", player.AverageLife)
+                .AddField("Assists:", player.Assists)
+                .AddField("Score:", player.Score)
+                .WithColor(new Color(239, 133, 141));
 
-            embed.AddField("Best Killstreak:", bestKillsreak);
-            embed.AddField("Losses:", losses);
-            embed.AddField("Deaths:", deaths);
-            embed.AddField("Avg. Life:", avgLife);
-            embed.AddField("Assists:", assists);
-            embed.AddField("Score:", Score);
-
-
-            embed.WithColor(new Color(239, 133, 141));
-
-            var msg = await Context.Channel.SendMessageAsync("", false, embed.Build());
+            await Context.Channel.SendMessageAsync(embed: embed.Build());
         }
     }
 }

--- a/CodMwStats.Commands/MainStatsCommands/XboxStats.cs
+++ b/CodMwStats.Commands/MainStatsCommands/XboxStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using CodMwStats.ApiWrapper;
 using CodMwStats.ApiWrapper.Models;
 using Discord;
@@ -20,48 +17,29 @@ namespace CodMwStats.Commands.MainStatsCommands
                 await ApiProcessor.GetUser($"https://api.tracker.gg/api/v2/modern-warfare/standard/profile/xbl/{userName}");
             var apiData = JsonConvert.DeserializeObject<ModerWarfareApiOutput>(jsonAsString);
 
-            var name = apiData.Data.PlatformInfo.PlatformUserHandle;
-            var pfp = apiData.Data.PlatformInfo.AvatarUrl;
-            var playTime = apiData.Data.Segment[0].Stats.TimePlayedTotal.Value;
-            var matches = apiData.Data.Segment[0].Stats.TotalGamesPlayed.Value;
-            var levelImg = apiData.Data.Segment[0].Stats.Level.Metadata.IconUrl;
-            var level = apiData.Data.Segment[0].Stats.Level.Value;
-            var levelper = apiData.Data.Segment[0].Stats.LevelProgression.Value;
-            var kd = apiData.Data.Segment[0].Stats.KdRatio.Value;
-            var kills = apiData.Data.Segment[0].Stats.Kills.Value;
-            var WinPer = apiData.Data.Segment[0].Stats.WlRatio.Value;
-            var wins = apiData.Data.Segment[0].Stats.Wins.Value;
-            var bestKillsreak = apiData.Data.Segment[0].Stats.LongestKillstreak.Value;
-            var losses = apiData.Data.Segment[0].Stats.Losses.Value;
-            var deaths = apiData.Data.Segment[0].Stats.Deaths.Value;
-            var avgLife = apiData.Data.Segment[0].Stats.AverageLife.Value;
-            var assists = apiData.Data.Segment[0].Stats.Assists.Value;
-            var Score = apiData.Data.Segment[0].Stats.CareerScore.Value;
+            var player = new ModerWarfarePlayer(apiData);
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle($"Stats of {name}");
-            embed.WithThumbnailUrl(pfp);
-            embed.AddField("Play Time:", playTime);
-            embed.AddField("Matches:", matches);
-            embed.AddField("Level:", level);
-            embed.AddField("Level Progression:", levelper);
-            embed.WithImageUrl(levelImg.ToString());
-            embed.AddField("K/D Ratio:", kd);
-            embed.AddField("Kills:", kills);
-            embed.AddField("Win %:", WinPer);
-            embed.AddField("Wins:", wins);
+            var embed = new EmbedBuilder()
+                .WithTitle($"Stats of {player.Name}")
+                .WithThumbnailUrl(player.ProfilePicURl.AbsoluteUri)
+                .AddField("Play Time:", player.Playtime)
+                .AddField("Matches:", player.Matches)
+                .AddField("Level:", player.Level)
+                .AddField("Level Progression:", player.LevelProgression)
+                .WithImageUrl(player.LevelImageUrl.AbsoluteUri)
+                .AddField("K/D Ratio:", player.KillDeathRatio)
+                .AddField("Kills:", player.Kills)
+                .AddField("Win %:", player.WinLossRation)
+                .AddField("Wins:", player.Wins)
+                .AddField("Best Killstreak:", player.BestKillStreak)
+                .AddField("Losses:", player.Losses)
+                .AddField("Deaths:", player.Deaths)
+                .AddField("Avg. Life:", player.AverageLife)
+                .AddField("Assists:", player.Assists)
+                .AddField("Score:", player.Score)
+                .WithColor(new Color(239, 133, 141));
 
-            embed.AddField("Best Killstreak:", bestKillsreak);
-            embed.AddField("Losses:", losses);
-            embed.AddField("Deaths:", deaths);
-            embed.AddField("Avg. Life:", avgLife);
-            embed.AddField("Assists:", assists);
-            embed.AddField("Score:", Score);
-
-
-            embed.WithColor(new Color(239, 133, 141));
-
-            var msg = await Context.Channel.SendMessageAsync("", false, embed.Build());
+            await Context.Channel.SendMessageAsync(embed: embed.Build());
         }
     }
 }


### PR DESCRIPTION
## 🤔 What's changed

### These changes only effect the project `CodMwStats.ApiWrapper`

* Remove the duplicated code from all `MainStatsCommands` modules.
* Add a `ModerWarfarePlayer` class that builds the player data from the API output data.
* Remove unused using declerations.
* Refactor each module to chain the embed builder methods and also remove the need to specify an empty string and useless bool for the SendMessageAsync method.

## 💡 Other proposed changes 

* `Context.Channel.SendMessageAsync()` can be simplfied to `ReplyAsync()` at your discression.
* The call `await ApiProcessor.GetUser($"https://api.tracker.gg/api/v2/modern-warfare/standard/profile/battlenet/{userName}");` 
    * couble be simplified to `await ApiProcessor.GetUser(SystemType.Battlenet, userName);`
    * This would make more sense as it feels like the ApiProcessors job to handle the URL, not the command module.

I can implement the above suggested changes if you wish. 

### ⚠️ Note that you should not merge this PR if you want me to do these proposed changes
